### PR TITLE
new command line parsing

### DIFF
--- a/mips2c.h
+++ b/mips2c.h
@@ -58,6 +58,8 @@
 #define debug(x) if(check_flag(f_debug)) printf(ANSI_COLOR_BRIGHT_GREEN "Debug" ANSI_COLOR_RESET ": " x "\n")
 #define warning(x) if(check_flag(f_display_warnings)) printf(ANSI_COLOR_CYAN "Warning" ANSI_COLOR_RESET ": " x "\n")
 
+#define MAJOR_VERSION 0
+#define MINOR_VERSION 2
 
 // typedefs ===============================================
 typedef struct {


### PR DESCRIPTION
ok, moved command line parsing to `getopts_long` so we can do things like `./mips2c --help` or `./mips2c -h` now.
no longer have to pass in `-l filename`, can just use `./mips2c filename.asm` now!