### PR TITLE
allow error to take formatted strings as input now

### DIFF
--- a/examples/badjmp.asm
+++ b/examples/badjmp.asm
@@ -1,0 +1,2 @@
+label1:
+j label2

--- a/src/error.c
+++ b/src/error.c
@@ -3,12 +3,23 @@
 */
 #include "headers/mips2c.h"
 #include <stdio.h>
+#include <stdarg.h>
 
-// plump this up? print to stderr as well for error logging?
-void error(char* error)
+// may want to print this to stderr no matter what? how would we handle this
+// in ncurses mode? some errors might be salvagable and we'll want to bounce back from
+// them?
+void error(const char * errmsg, ... )
 {
-	PRINT(ANSI_COLOR_RED "\nERROR" ANSI_COLOR_RESET ": %s\n", error);
-	// fprintf(stderr, "%s\n", error);
+	PRINT(ANSI_COLOR_RED "\nERROR" ANSI_COLOR_RESET ": ");
+	va_list args;
+	va_start (args, errmsg);
+	if (!check_flag(f_curses))
+		vprintf (errmsg, args);
+	else if (check_flag(f_curses))
+		vwprintw(stdscr, errmsg, args);
+	va_end (args);
+
 	exit_info();
 	exit(1);
+
 }

--- a/src/headers/mips2c.h
+++ b/src/headers/mips2c.h
@@ -123,13 +123,14 @@ extern label_list* labels;
 
 // functions ========================================================
 void PRINT( const char * format, ... );
+void error(const char * errmsg, ... );
 void single_exitpoint(int status);
 program get_program(char* filename);
 // int free_program(char** program);
 int str_to_int(char* str);	// just in case atoi is a no go
 void exit_info();
 int align4(int num);
-void error(char* error);
+
 
 // for debugging purposes
 void print_labels();

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -1298,7 +1298,6 @@ void print_instruction(parsed_instruction* p) {
 // helper functions here!
 int get_line_from_labels(char* search_label)
 {
-	//  if (debug) print_labels();
 	label_list *curr = labels;
 	while (curr != NULL)
 	{
@@ -1309,9 +1308,6 @@ int get_line_from_labels(char* search_label)
 
 		curr = curr->next;
 	}
-
-	char err_msg[128];
-	sprintf(err_msg, "Cannot find label %s", search_label);
-	error(err_msg);
+	error("Cannot find label %s", search_label);
 	return -1;
 }

--- a/src/mips2c.c
+++ b/src/mips2c.c
@@ -7,8 +7,8 @@
 	todo:
 		- support for macros
 		- write more tests
+			- there should be unit testing written with Check in C
 		- doesn't display text accurately rn when parsing
-	    - should replace , with ' '
 		- bubble sort still isn't working? why? try re-downloading,
 		  why does some syntax have to change? implement that next!
 		  such as wordd 12:0 or whatever it was!
@@ -78,13 +78,13 @@
 
 void PRINT( const char * format, ... )
 {
-  va_list args;
-  va_start (args, format);
-  if (!check_flag(f_curses))
-  	vprintf (format, args);
-  else if (check_flag(f_curses))
-  	vwprintw(stdscr, format, args);
-  va_end (args);
+	va_list args;
+	va_start (args, format);
+	if (!check_flag(f_curses))
+		vprintf (format, args);
+	else if (check_flag(f_curses))
+		vwprintw(stdscr, format, args);
+	va_end (args);
 }
 
 // private functions
@@ -440,9 +440,7 @@ void parse_program(program* p)
 	    {
 	    	if (isalpha(p->source[i][0]) == 0)
 	    	{
-    			char err_msg[128];
-				sprintf(err_msg, "Label %s must start with alphabetic character", p->source[i]);
-				error(err_msg);
+				error("Label %s must start with alphabetic character", p->source[i]);
 	    	}
 
 


### PR DESCRIPTION
fix up error printing function to avoid having to sprintf format strings to pass to it, now you can just do something like `error("bad instruction %s", instruction->name)`